### PR TITLE
Update workflowInstance.js

### DIFF
--- a/lib/es6/hosting/workflowInstance.js
+++ b/lib/es6/hosting/workflowInstance.js
@@ -198,7 +198,7 @@ WorkflowInstance.prototype.setWorkflow = function (execContext, workflowVersion,
 WorkflowInstance.prototype.callMethod = async(function* (methodName, args) {
     let self = this;
 
-    self._resetCallbacksAndState();
+    self._resetCallbacksAndState(methodName);
 
     let endMethodReached = false;
     let result = null;
@@ -270,9 +270,15 @@ WorkflowInstance.prototype._resetCallbacks = function () {
     this._idleInstanceIdPathCallback = null;
 };
 
-WorkflowInstance.prototype._resetCallbacksAndState = function () {
+WorkflowInstance.prototype._resetCallbacksAndState = function (methodName) {
     this._resetCallbacks();
-    this.activeDelays = [];
+    if (_.isString(methodName)) {
+        _.remove(this.activeDelays, function(elem) {
+            return methodName === elem.methodName;
+        });
+    } else {
+        this.activeDelays = [];
+    }
 };
 
 WorkflowInstance.prototype._addBeginMethodWithCreateInstHelperTracker = function () {


### PR DESCRIPTION
parallel task scheduling fix: every callMethod makes activeDelays empty (via _resetCallbacksAndState which removes other delays too), so a filter is needed to remove only one delay identified by the methodName argument
